### PR TITLE
Bump to v0.7.4 and add gabrielcnr and traversaro as mantainers

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @PhilipVinc @andsteing @avital @jheek @levskaya
+* @PhilipVinc @andsteing @avital @gabrielcnr @jheek @levskaya @traversaro

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,7 +34,7 @@ CONDARC
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
     pip mamba conda-build boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,10 @@ pkgs_dirs:
 
 CONDARC
 
-
-mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
-mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
+mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -12,7 +12,7 @@ function startgroup {
             echo "##[group]$1";;
         travis )
             echo "$1"
-            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:start:'"${1// /}"'\r';;
         github_actions )
             echo "::group::$1";;
         * )
@@ -28,7 +28,7 @@ function endgroup {
         azure )
             echo "##[endgroup]";;
         travis )
-            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:end:'"${1// /}"'\r';;
         github_actions )
             echo "::endgroup::";;
     esac

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Feedstock Maintainers
 * [@PhilipVinc](https://github.com/PhilipVinc/)
 * [@andsteing](https://github.com/andsteing/)
 * [@avital](https://github.com/avital/)
+* [@gabrielcnr](https://github.com/gabrielcnr/)
 * [@jheek](https://github.com/jheek/)
 * [@levskaya](https://github.com/levskaya/)
+* [@traversaro](https://github.com/traversaro/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,4 +57,3 @@ extra:
     - levskaya
     - andsteing
     - gabrielcnr
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,3 +57,4 @@ extra:
     - levskaya
     - andsteing
     - gabrielcnr
+    - traversaro

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 20b2f92971101be5214689d6f035ee1e7fde55e4d079ee23086b5682bac2cbf4 
+  sha256: d697323b557e92c1372798c2e2ae44bb7c123647158fc878bc765e45e25d990d 
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "flax" %}
-{% set version = "0.6.1" %}
+{% set version = "0.7.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,24 +7,28 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 29960fb51d7b65dc692dd9935d9b0fc9ba3bf50943746a0ebeb55346816d8b54
+  sha256: 20b2f92971101be5214689d6f035ee1e7fde55e4d079ee23086b5682bac2cbf4 
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - python >=3.6
     - pip
+    - setuptools
+    - setuptools-scm
   run:
     - python >=3.6
-    - jax >=0.3.2
+    - jax >=0.4.2
     - matplotlib-base
     - msgpack-python
     - numpy >=1.12
     - optax
+    - orbax-checkpoint
+    - tensorstore
     - rich >=11.1.0
     - typing_extensions >=4.1.1
     - pyyaml >=5.4.1
@@ -52,3 +56,5 @@ extra:
     - avital
     - levskaya
     - andsteing
+    - gabrielcnr
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "flax" %}
-{% set version = "0.7.1" %}
+{% set version = "0.7.4" %}
 
 package:
   name: {{ name|lower }}
@@ -21,8 +21,8 @@ requirements:
     - setuptools
     - setuptools-scm
   run:
-    - python >=3.6
-    - jax >=0.4.2
+    - python >=3.9
+    - jax >=0.4.11
     - matplotlib-base
     - msgpack-python
     - numpy >=1.12
@@ -30,7 +30,7 @@ requirements:
     - orbax-checkpoint
     - tensorstore
     - rich >=11.1.0
-    - typing_extensions >=4.1.1
+    - typing_extensions >=4.2.0
     - pyyaml >=5.4.1
 
 test:


### PR DESCRIPTION
Based on https://github.com/conda-forge/flax-feedstock/pull/28 by  @gabrielcnr .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
