### PR TITLE
MNT: Update to flax v0.12.2

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: 0.12.1
+  version: "0.12.2"
   python_min: "3.11"
 
 package:
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/f/flax/flax-${{ version }}.tar.gz
-  sha256: ce2229a2ecb689678ba619e822346447c173c2ac1635e674e8249b97ed816cab
+  sha256: e9723b0881e571abe61885bb8770f53fdb3c383b6b3f5a923dcf6f1e9a687905
 
 build:
   number: 0


### PR DESCRIPTION
* c.f. https://github.com/google/flax/releases/tag/v0.12.2
* Needed for https://github.com/conda-forge/gpjax-feedstock/pull/12

Given no dependency changes in https://github.com/google/flax/compare/v0.12.1...v0.12.2 this should just be a patch release bump.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [N/A] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
